### PR TITLE
SLING-12981 migrate to Jakarta Servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.commons.fsclassloader</artifactId>
-    <version>1.0.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Apache Sling Commons FileSystem ClassLoader</name>
     <description>The Sling Commons FileSystem ClassLoader bundle provides a dynamic class loader for reading
@@ -42,13 +42,15 @@
     </scm>
 
     <properties>
-        <sling.java.version>8</sling.java.version>
+        <sling.java.version>17</sling.java.version>
+        <slf4j.version>2.0.17</slf4j.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -83,14 +85,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.18.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -102,7 +111,7 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.webconsole</artifactId>
-            <version>3.0.0</version>
+            <version>5.0.10</version>
             <scope>provided</scope>
         </dependency>
 
@@ -115,7 +124,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.9.0</version>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -127,6 +136,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
+++ b/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
@@ -18,12 +18,6 @@
  */
 package org.apache.sling.commons.fsclassloader.impl;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -32,10 +26,14 @@ import java.io.Writer;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.felix.webconsole.AbstractWebConsolePlugin;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.felix.webconsole.servlet.AbstractServlet;
 import org.apache.sling.commons.classloader.ClassLoaderWriter;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -59,7 +57,7 @@ import org.slf4j.LoggerFactory;
             "felix.webconsole.css=" + FSClassLoaderWebConsole.RES_LOC + "/prettify.css",
             "felix.webconsole.category=Sling"
         })
-public class FSClassLoaderWebConsole extends AbstractWebConsolePlugin {
+public class FSClassLoaderWebConsole extends AbstractServlet {
 
     static final String APP_ROOT = "fsclassloader";
 
@@ -82,11 +80,6 @@ public class FSClassLoaderWebConsole extends AbstractWebConsolePlugin {
     private static final long serialVersionUID = -5728679635644481848L;
 
     /**
-     * The servlet configuration
-     */
-    private ServletConfig config;
-
-    /**
      * Activate this component. Create the root directory.
      *
      * @param componentContext
@@ -97,14 +90,6 @@ public class FSClassLoaderWebConsole extends AbstractWebConsolePlugin {
         // get the file root
         this.root = CacheLocationUtils.getRootDir(componentContext.getBundleContext(), config);
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see javax.servlet.Servlet#destroy()
-     */
-    @Override
-    public void destroy() {}
 
     /*
      * (non-Javadoc)
@@ -180,56 +165,6 @@ public class FSClassLoaderWebConsole extends AbstractWebConsolePlugin {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.felix.webconsole.AbstractWebConsolePlugin#getLabel()
-     */
-    @Override
-    public String getLabel() {
-        return "fsclassloader";
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see javax.servlet.Servlet#getServletConfig()
-     */
-    @Override
-    public ServletConfig getServletConfig() {
-        return this.config;
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see javax.servlet.Servlet#getServletInfo()
-     */
-    @Override
-    public String getServletInfo() {
-        return "";
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.felix.webconsole.AbstractWebConsolePlugin#getTitle()
-     */
-    @Override
-    public String getTitle() {
-        return "File System Class Loader";
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see javax.servlet.Servlet#init(javax.servlet.ServletConfig)
-     */
-    @Override
-    public void init(ServletConfig config) throws ServletException {
-        this.config = config;
-    }
-
     /**
      * Checks whether the specified file is a file and is underneath the root
      * directory.
@@ -285,11 +220,11 @@ public class FSClassLoaderWebConsole extends AbstractWebConsolePlugin {
      * (non-Javadoc)
      *
      * @see
-     * org.apache.felix.webconsole.AbstractWebConsolePlugin#renderContent(javax
+     * org.apache.felix.webconsole.servlet.AbstractServlet#renderContent(javax
      * .servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
      */
     @Override
-    protected void renderContent(HttpServletRequest request, HttpServletResponse response)
+    public void renderContent(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         Map<String, ScriptFiles> scripts = new LinkedHashMap<String, ScriptFiles>();
         readFiles(root, root, scripts);

--- a/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
+++ b/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
@@ -67,7 +67,7 @@ public class FSClassLoaderWebConsole extends AbstractServlet {
     private static final Logger LOG = LoggerFactory.getLogger(FSClassLoaderWebConsole.class);
 
     @Reference(target = "(component.name=org.apache.sling.commons.fsclassloader.impl.FSClassLoaderProvider)")
-    private transient ClassLoaderWriter classLoaderWriter;
+    private ClassLoaderWriter classLoaderWriter;
 
     /**
      * The root under which the class files are under

--- a/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
+++ b/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
@@ -67,7 +67,7 @@ public class FSClassLoaderWebConsole extends AbstractServlet {
     private static final Logger LOG = LoggerFactory.getLogger(FSClassLoaderWebConsole.class);
 
     @Reference(target = "(component.name=org.apache.sling.commons.fsclassloader.impl.FSClassLoaderProvider)")
-    private ClassLoaderWriter classLoaderWriter;
+    private transient ClassLoaderWriter classLoaderWriter;
 
     /**
      * The root under which the class files are under

--- a/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
+++ b/src/main/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsole.java
@@ -66,8 +66,7 @@ public class FSClassLoaderWebConsole extends AbstractServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(FSClassLoaderWebConsole.class);
 
-    @Reference(target = "(component.name=org.apache.sling.commons.fsclassloader.impl.FSClassLoaderProvider)")
-    private ClassLoaderWriter classLoaderWriter;
+    private final transient ClassLoaderWriter classLoaderWriter;
 
     /**
      * The root under which the class files are under
@@ -86,7 +85,12 @@ public class FSClassLoaderWebConsole extends AbstractServlet {
      *            the component context
      */
     @Activate
-    protected void activate(final ComponentContext componentContext, final FSClassLoaderComponentConfig config) {
+    public FSClassLoaderWebConsole(
+            @Reference(target = "(component.name=org.apache.sling.commons.fsclassloader.impl.FSClassLoaderProvider)")
+                    ClassLoaderWriter classLoaderWriter,
+            final ComponentContext componentContext,
+            final FSClassLoaderComponentConfig config) {
+        this.classLoaderWriter = classLoaderWriter;
         // get the file root
         this.root = CacheLocationUtils.getRootDir(componentContext.getBundleContext(), config);
     }

--- a/src/test/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsoleTest.java
+++ b/src/test/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsoleTest.java
@@ -27,6 +27,8 @@ import org.apache.sling.commons.classloader.ClassLoaderWriter;
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
 import org.powermock.reflect.Whitebox;
 
 import static org.junit.Assert.assertEquals;
@@ -94,8 +96,12 @@ public class FSClassLoaderWebConsoleTest {
     }
 
     private void setFixture(boolean clwReturn) {
-        console = spy(new FSClassLoaderWebConsole());
         classLoaderWriter = mock(ClassLoaderWriter.class);
+        ComponentContext componentContext = mock(ComponentContext.class);
+        BundleContext bundleContext = mock(BundleContext.class);
+        Mockito.doReturn(bundleContext).when(componentContext).getBundleContext();
+        FSClassLoaderComponentConfig config = mock(FSClassLoaderComponentConfig.class);
+        console = spy(new FSClassLoaderWebConsole(classLoaderWriter, componentContext, config));
         when(classLoaderWriter.delete("")).thenReturn(clwReturn);
         Whitebox.setInternalState(console, "classLoaderWriter", classLoaderWriter);
     }

--- a/src/test/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsoleTest.java
+++ b/src/test/java/org/apache/sling/commons/fsclassloader/impl/FSClassLoaderWebConsoleTest.java
@@ -18,12 +18,11 @@
  */
 package org.apache.sling.commons.fsclassloader.impl;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.sling.commons.classloader.ClassLoaderWriter;
 import org.junit.After;
 import org.junit.Test;


### PR DESCRIPTION
bump bundle major version to 2.0.0
bump minimum jdk to 17
bump slf4j-api to the 2.x version
migrate the javax.servlet references to jakarta.servlet

refactor the test to use the jakarta servlet based apis